### PR TITLE
Fix to use the primary image for the operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ APP_PARAMETERS ?= { \
 app/build:: .build/redis-enterprise-operator/deployer \
 			.build/redis-enterprise-operator/primary \
 			.build/redis-enterprise-operator/usage-meter \
-			 .build/redis-enterprise-operator/operator \
+			# .build/redis-enterprise-operator/operator \
 			# .build/redis-enterprise-operator/redis \
 			# .build/redis-enterprise-operator/k8s-controller \
 			# .build/redis-enterprise-operator/billing-agent \
@@ -119,8 +119,8 @@ app/build:: .build/redis-enterprise-operator/deployer \
 
 # Operator image is the what Google calls the primary image.
 # Label the primary image with the same tag as deployer image.
-# From the partner portal, primary image is queried using the same tag 
-# as deployer image. When pulling the image from docker hub use 
+# From the partner portal, primary image is queried using the same tag
+# as deployer image. When pulling the image from docker hub use
 # the redis native tag and push that image as primary image with deployer tag.
 .build/redis-enterprise-operator/primary: .build/var/REGISTRY \
 										  .build/var/OPERATOR_TAG \

--- a/chart/redis-operator/templates/deployment/operator.yaml
+++ b/chart/redis-operator/templates/deployment/operator.yaml
@@ -18,7 +18,7 @@ spec:
         {{- include "initContainerWaitForCRDsDeploy" . | nindent 6 }}
       containers:
         - name: redis-enterprise-operator
-          image: {{ .Values.operator.image.repository }}/operator:{{ .Values.operator.image.tag }}
+          image: {{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}
           command:
             - redis-enterprise-operator
           imagePullPolicy: Always


### PR DESCRIPTION
Moved to use the primary image as the operator as the publishing of the draft misses the operator in a separate path.