### PR TITLE
CI integration

### DIFF
--- a/chart/redis-operator/templates/service/admission-service.yaml
+++ b/chart/redis-operator/templates/service/admission-service.yaml
@@ -1,6 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: redis-enterprise
+    app.kubernetes.io/name: redis-enterprise-operator
   name: admission
 spec:
   ports:

--- a/testapp-role.yaml
+++ b/testapp-role.yaml
@@ -1,0 +1,8 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: testapp
+rules:
+  - apiGroups: ["app.k8s.io"]
+    resources: ["applications"]
+    verbs: ["*"]

--- a/testapp-rolebinding.yaml
+++ b/testapp-rolebinding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: testapp
+subjects:
+- kind: ServiceAccount
+  name: default
+- kind: ServiceAccount
+  name: redis-enterprise-operator
+roleRef:
+  kind: Role
+  name: testapp
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
- add dev/install make target, replacing dev-test-install.sh script
- missing testapp role+binding for dev/CI deployments
- admission service was not cleaned up