### PR TITLE
RED-65561 - adding permissions for deploy service account job

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -154,6 +154,9 @@ properties:
             - apiGroups: [""]
               resources: ["services", "secrets"]
               verbs: ["*"]
+            - apiGroups: ["app.redislabs.com"]
+              resources: ["redisenterpriseclusters"]
+              verbs: ["get", "create", "patch"]
   operator.replicas:
     type: integer
     title: Number of Cluster Nodes


### PR DESCRIPTION
mpdev verify failed as a result of the deploy service account job not having right permissions for creating the Redis Enterprise Cluster CR